### PR TITLE
Add request dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "preferGlobal": true,
   "dependencies": {
     "nopt": "~1.0.10",
+    "request": "~2.34.1",
     "xml2js": "~0.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Foscam fails when trying to save a snapshot because request isn't defined in the deps
