### PR TITLE
Remove tmp from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 npm-debug.log
-tmp


### PR DESCRIPTION
@imbrianj Since you're using it for lock files and caches, removing this from .gitignore. When you npm install from the repo tmp doesn't not get carried over since it's ignored which makes writing to this directory fail. Ideally, we switch the code to use mkdirp so this is automatically created at run time
